### PR TITLE
Change in area calculation per pixel in km²

### DIFF
--- a/R/get_ghsl.R
+++ b/R/get_ghsl.R
@@ -34,8 +34,7 @@ get_ghsl <- function(region, scale = 100) {
     img_base <- ee$ImageCollection("users/ambarja/ghsl")$
       toBands()
 
-    ghsl_area <- img_base$multiply(ee$Image$pixelArea())$
-      divide(1000000)
+    ghsl_area <- img_base$ divide(1000000)
 
     data <- ee_sum(
       x = ghsl_area,


### PR DESCRIPTION
The area calculation per pixel is already done in the original database ("JRC/GHSL/P2023A/GHS_BUILT_S"), it just needs to be converted from m² to km².